### PR TITLE
small python3 compatibility issue

### DIFF
--- a/legacy/mama_parse.py
+++ b/legacy/mama_parse.py
@@ -71,7 +71,6 @@ def __ID_List_Factory__(colnames, keepcol, fname_end, header=None, usecols=None)
 
         def loj(self, externalDf):
             '''Returns indices of those elements of self.IDList that appear in exernalDf.'''
-            import pdb; pdb.set_trace()
             r = externalDf.columns[0]
             l = self.IDList.columns[0]
             merge_df = externalDf.iloc[:, [0]]


### PR DESCRIPTION
I noticed something very small while trying to generate some ld scores today. This isn't an issue when run in python2.x, but with 3.x it needs to be cast to a list first. 