### PR TITLE
fix imports in ldsc

### DIFF
--- a/legacy/mama_ldscore.py
+++ b/legacy/mama_ldscore.py
@@ -38,11 +38,8 @@ import subprocess
 import copy
 import argparse
 
-# these imports don't work as written
-# from legacy import mama_ldcalc as ld
-# from legacy import mama_parse as ps
-import mama_ldcalc as ld
-import mama_parse as ps
+import legacy.mama_ldcalc as ld
+import legacy.mama_parse as ps
 
 __version__ = '1.0.0'
 


### PR DESCRIPTION
Very small change to allow mama_ldscore to be called from outside of the legacy folder. 