### PR TITLE
Add mean chi squared for (harmonized) input pops to log

### DIFF
--- a/core_mama.py
+++ b/core_mama.py
@@ -176,7 +176,7 @@ def run_mama_method(betas, omega, sigma):
     """
 
     # Get values for M and P (used to keep track of slices / indices / broadcasting)
-    M, P, *extra_dimensions = omega.shape
+    M, P, *extra_dimensions = omega.shape  # pylint: disable=unused-variable
 
     # Create a 3D matrix, M rows of Px1 column vectors with shape (M, P, 1)
     d_indices = np.arange(P)

--- a/mama_ldscores.py
+++ b/mama_ldscores.py
@@ -11,4 +11,3 @@ from legacy.mama_ldscore import main_func
 
 if __name__ == '__main__':
     main_func(sys.argv)
-

--- a/test/system/e2e_test.py
+++ b/test/system/e2e_test.py
@@ -90,6 +90,14 @@ class TestEndToEnd:
         assert "Number of SNPS in initial intersection of all sources: 32" in logtext
         assert "Number of SNPS in initial intersection of all sources: 32" in sout
 
+        assert "Writing harmonized summary statistics to disk" in logtext
+        assert "Writing harmonized summary statistics to disk" in sout
+
+        assert "Harmonized POP1 PHENO1 mean chi squared:" not in logtext
+        assert "Harmonized POP1 PHENO1 mean chi squared:" not in sout
+        assert "Harmonized POP2 PHENO1 mean chi squared:" not in logtext
+        assert "Harmonized POP2 PHENO1 mean chi squared:" not in sout
+
         assert "SNPs to make omega positive semi-definite" in logtext
         assert "SNPs to make omega positive semi-definite" in sout
 
@@ -208,6 +216,12 @@ class TestEndToEnd:
 
         assert "Number of SNPS in initial intersection of all sources: 32" in logtext
         assert "Number of SNPS in initial intersection of all sources: 32" in sout
+
+        assert "Writing harmonized summary statistics to disk" in logtext
+        assert "Writing harmonized summary statistics to disk" in sout
+
+        assert "Harmonized POP1 PHENO1 mean chi squared:" not in logtext
+        assert "Harmonized POP1 PHENO1 mean chi squared:" not in sout
 
         assert "SNPs to make omega positive semi-definite" not in logtext
         assert "SNPs to make omega positive semi-definite" not in sout


### PR DESCRIPTION
* As in the title, the mean chi squared of the inputs (after harmonization)
  will be added to debug logging

* Fix Pandas versioning information addition to log (previously it just
  went to the console and not the log)

* The mean chi squared addition came with some refactoring to create
  functions to calculate z scores and mean chi squared

* Added tests for the new functions, as well as added a bit to testing
  for P calculations

* Some minor pylint fixes